### PR TITLE
fix: Node18 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "ethereum-waffle": "^3.4.4",
     "ethers": "^5.6.8",
-    "hardhat": "^2.9.9",
+    "hardhat": "^2.12.7",
     "hardhat-abi-exporter": "^2.9.0",
     "husky": "^8.0.1",
     "lint-staged": "^13.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5648,7 +5648,7 @@ hardhat-abi-exporter@^2.9.0:
     "@ethersproject/abi" "^5.5.0"
     delete-empty "^3.0.0"
 
-hardhat@^2.9.9:
+hardhat@^2.12.7:
   version "2.12.7"
   resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.12.7.tgz#d8de2dc32e9a2956d53cf26ef4cd5857e57a3138"
   integrity sha512-voWoN6zn5d8BOEaczSyK/1PyfdeOeI3SbGCFb36yCHTJUt6OIqLb+ZDX30VhA1UsYKzLqG7UnWl3fKJUuANc6A==


### PR DESCRIPTION
Hardhat has introduced support for NodeJS 18.x at version `2.10.0` and `package.json` is set to `^2.9.9`; the `backend` has been updated to NodeJS18 months ago and we aren't looking at downgrading the version. 
Even though the installed version is higher, it can sometimes cause issues when installing deps from a fresh install' with the node engine throwing an error than `node: ^18.0.0` isn't supported; this patch sets the same version in the `package.json` as the `yarn.lock`

> Documentation: https://github.com/NomicFoundation/hardhat/releases/tag/hardhat%402.10.0