### PR TITLE
build: Remove unwanted files from the build folder

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,7 +1,7 @@
 {
   "extends": "@istanbuljs/nyc-config-typescript",
   "all": true,
-  "include": ["src/**"],
-  "exclude": ["src/__tests__/**", "src/abis/**", "src/constants/**", "src/contracts/**", "src/index.ts"],
+  "include": ["src/**/*.ts", "src/**/*.js"],
+  "exclude": ["src/__tests__/**", "src/constants/**", "src/index.ts", "src/typechain/**"],
   "reporter": ["html", "text"]
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -41,12 +41,12 @@ const config = {
     only: ["LooksRareProtocol", "TransferManager", "OrderValidatorV2A", "IERC721", "IERC1155", "IERC20", "IWETH"],
   },
   typechain: {
-    outDir: "typechain",
+    outDir: "src/typechain",
     target: "ethers-v5",
   },
   paths: {
     tests: "src/__tests__",
-    artifacts: "artifacts",
+    artifacts: "src/artifacts",
     sources: "src/contracts",
   },
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
-  "types": "dist/src/index.d.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],
@@ -25,7 +25,7 @@
     "node": ">= 16.15.1 <=18.14.2"
   },
   "scripts": {
-    "prebuild": "rm -rf typechain dist artifacts cache",
+    "prebuild": "rm -rf ./src/typechain ./src/artifacts cache dist",
     "prepublishOnly": "yarn build",
     "dev": "rollup -c --bundleConfigAsCjs -w",
     "build:ts": "rollup -c --bundleConfigAsCjs && tsc -d",
@@ -33,9 +33,9 @@
     "build": "yarn build:sc && yarn build:ts",
     "test": "nyc hardhat test",
     "doc": "typedoc --plugin typedoc-plugin-markdown",
-    "lint": "eslint --max-warnings 0 'src/**/*.{js,jsx,ts,tsx}'",
-    "format:check": "prettier --check 'src/**/*.{js,jsx,ts,tsx,json,yaml,yml,md}'",
-    "format:write": "prettier --write 'src/**/*.{js,jsx,ts,tsx,json,yaml,yml,md}'",
+    "lint": "eslint --max-warnings 0 'src/**/*.{js,ts}'",
+    "format:check": "prettier --check 'src/**/*.{js,ts,json,yaml,yml,md}'",
+    "format:write": "prettier --write 'src/**/*.{js,ts,json,yaml,yml,md}'",
     "release": "release-it --only-version --set-upstream"
   },
   "lint-staged": {

--- a/src/__tests__/helpers/setup.ts
+++ b/src/__tests__/helpers/setup.ts
@@ -5,15 +5,15 @@ import chaiAsPromised from "chai-as-promised";
 import { ethers } from "hardhat";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { Addresses } from "../../types";
-import type { LooksRareProtocol } from "../../../typechain/@looksrare/contracts-exchange-v2/contracts/LooksRareProtocol";
-import type { TransferManager } from "../../../typechain/@looksrare/contracts-exchange-v2/contracts/TransferManager";
-import type { StrategyCollectionOffer } from "../../../typechain/@looksrare/contracts-exchange-v2/contracts/executionStrategies/StrategyCollectionOffer";
-import type { CreatorFeeManagerWithRoyalties } from "../../../typechain/@looksrare/contracts-exchange-v2/contracts/CreatorFeeManagerWithRoyalties";
-import type { OrderValidatorV2A } from "../../../typechain/@looksrare/contracts-exchange-v2/contracts/helpers/OrderValidatorV2A";
-import type { MockERC721 } from "../../../typechain/src/contracts/tests/MockERC721";
-import type { MockERC1155 } from "../../../typechain/src/contracts/tests/MockERC1155";
-import type { WETH } from "../../../typechain/solmate/src/tokens/WETH";
-import type { Verifier } from "../../../typechain/src/contracts/tests/Verifier";
+import type { LooksRareProtocol } from "../../typechain/@looksrare/contracts-exchange-v2/contracts/LooksRareProtocol";
+import type { TransferManager } from "../../typechain/@looksrare/contracts-exchange-v2/contracts/TransferManager";
+import type { StrategyCollectionOffer } from "../../typechain/@looksrare/contracts-exchange-v2/contracts/executionStrategies/StrategyCollectionOffer";
+import type { CreatorFeeManagerWithRoyalties } from "../../typechain/@looksrare/contracts-exchange-v2/contracts/CreatorFeeManagerWithRoyalties";
+import type { OrderValidatorV2A } from "../../typechain/@looksrare/contracts-exchange-v2/contracts/helpers/OrderValidatorV2A";
+import type { MockERC721 } from "../../typechain/src/contracts/tests/MockERC721";
+import type { MockERC1155 } from "../../typechain/src/contracts/tests/MockERC1155";
+import type { WETH } from "../../typechain/solmate/src/tokens/WETH";
+import type { Verifier } from "../../typechain/src/contracts/tests/Verifier";
 
 chai.use(chaiAsPromised);
 

--- a/src/__tests__/looksrare/transferManager.test.ts
+++ b/src/__tests__/looksrare/transferManager.test.ts
@@ -1,8 +1,8 @@
 import { expect } from "chai";
 import { Contract } from "ethers";
 import { ethers } from "hardhat";
-import { ERC721 } from "../../../typechain/solmate/src/tokens/ERC721.sol/ERC721";
-import { ERC1155 } from "../../../typechain/solmate/src/tokens/ERC1155.sol/ERC1155";
+import { ERC721 } from "../../typechain/solmate/src/tokens/ERC721.sol/ERC721";
+import { ERC1155 } from "../../typechain/solmate/src/tokens/ERC1155.sol/ERC1155";
 import abiIERC721 from "../../abis/IERC721.json";
 import abiIERC1155 from "../../abis/IERC1155.json";
 import { setUpContracts, SetupMocks, getSigners, Signers } from "../helpers/setup";

--- a/src/utils/calls/exchange.ts
+++ b/src/utils/calls/exchange.ts
@@ -1,5 +1,5 @@
 import { Contract, PayableOverrides, constants } from "ethers";
-import { LooksRareProtocol } from "../../../typechain/@looksrare/contracts-exchange-v2/contracts/LooksRareProtocol";
+import { LooksRareProtocol } from "../../typechain/@looksrare/contracts-exchange-v2/contracts/LooksRareProtocol";
 import abiLooksRareProtocol from "../../abis/LooksRareProtocol.json";
 import { Maker, MerkleTree, Taker, Signer, ContractMethods } from "../../types";
 

--- a/src/utils/calls/nonces.ts
+++ b/src/utils/calls/nonces.ts
@@ -1,5 +1,5 @@
 import { Contract, BigNumber, Overrides, providers, BigNumberish } from "ethers";
-import { LooksRareProtocol } from "../../../typechain/@looksrare/contracts-exchange-v2/contracts/LooksRareProtocol";
+import { LooksRareProtocol } from "../../typechain/@looksrare/contracts-exchange-v2/contracts/LooksRareProtocol";
 import abi from "../../abis/LooksRareProtocol.json";
 import { Signer, ContractMethods } from "../../types";
 

--- a/src/utils/calls/orderValidator.ts
+++ b/src/utils/calls/orderValidator.ts
@@ -1,5 +1,5 @@
 import { Contract, Overrides, providers } from "ethers";
-import { OrderValidatorV2A } from "../../../typechain/@looksrare/contracts-exchange-v2/contracts/helpers/OrderValidatorV2A";
+import { OrderValidatorV2A } from "../../typechain/@looksrare/contracts-exchange-v2/contracts/helpers/OrderValidatorV2A";
 import abi from "../../abis/OrderValidatorV2A.json";
 import { Signer, Maker, MerkleTree, OrderValidatorCode } from "../../types";
 

--- a/src/utils/calls/strategies.ts
+++ b/src/utils/calls/strategies.ts
@@ -1,5 +1,5 @@
 import { Contract, Overrides, providers } from "ethers";
-import { LooksRareProtocol } from "../../../typechain/@looksrare/contracts-exchange-v2/contracts/LooksRareProtocol";
+import { LooksRareProtocol } from "../../typechain/@looksrare/contracts-exchange-v2/contracts/LooksRareProtocol";
 import abi from "../../abis/LooksRareProtocol.json";
 import { Signer, StrategyType, StrategyInfo } from "../../types";
 

--- a/src/utils/calls/tokens.ts
+++ b/src/utils/calls/tokens.ts
@@ -1,6 +1,6 @@
 import { Contract, providers, Overrides, CallOverrides, BigNumber } from "ethers";
-import { ERC721 } from "../../../typechain/solmate/src/tokens/ERC721.sol/ERC721";
-import { ERC20 } from "../../../typechain/solmate/src/tokens/ERC20";
+import { ERC721 } from "../../typechain/solmate/src/tokens/ERC721.sol/ERC721";
+import { ERC20 } from "../../typechain/solmate/src/tokens/ERC20";
 import abiIERC721 from "../../abis/IERC721.json";
 import abiIERC20 from "../../abis/IERC20.json";
 import { Signer } from "../../types";

--- a/src/utils/calls/transferManager.ts
+++ b/src/utils/calls/transferManager.ts
@@ -1,5 +1,5 @@
 import { Contract, Overrides, providers } from "ethers";
-import { TransferManager } from "../../../typechain/@looksrare/contracts-exchange-v2/contracts/TransferManager";
+import { TransferManager } from "../../typechain/@looksrare/contracts-exchange-v2/contracts/TransferManager";
 import abi from "../../abis/TransferManager.json";
 import { Signer, ContractMethods, BatchTransferItem } from "../../types";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -99,5 +99,7 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
-  }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/__tests__/**/*", "src/contracts/**/*", "src/artifacts/**/*"]
 }


### PR DESCRIPTION
The `dist` folder was a mess because some files were imported from outside the `src` folder.