### PR TITLE
chore: Allow Node.js 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/LooksRare/sdk-v2.git"
   },
   "engines": {
-    "node": ">= 16.15.1 <= 19.x"
+    "node": ">= 16.15.1 <= 20.x"
   },
   "scripts": {
     "prebuild": "rm -rf ./src/typechain ./src/artifacts cache dist",


### PR DESCRIPTION
Fix `error @looksrare/sdk-v2@1.0.0: The engine "node" is incompatible with this module. Expected version ">= 16.15.1 <= 19.x". Got "20.8.1"`

Node.js 20 is the new LTS (Long Term Support)

> https://github.com/nodejs/release#release-schedule