### PR TITLE
chore: Remove addresses from L2

### DIFF
--- a/src/constants/addresses.ts
+++ b/src/constants/addresses.ts
@@ -37,9 +37,9 @@ const sepoliaAddresses: Addresses = {
 };
 
 const arbitrumSepoliaAddresses: Addresses = {
-  LOOKS: "0x0000000000000000000000000000000000000000", // bridged LOOKS
+  LOOKS: "",
   EXCHANGE_V2: "",
-  TRANSFER_MANAGER_V2: "0x21D44Cd218895d08bB57E2161A5c8De1CE898165",
+  TRANSFER_MANAGER_V2: "",
   WETH: "",
   ORDER_VALIDATOR_V2: "",
   REVERSE_RECORDS: "",
@@ -49,9 +49,9 @@ const arbitrumSepoliaAddresses: Addresses = {
 };
 
 const arbitrumMainnetAddresses: Addresses = {
-  LOOKS: "0x0000000000000000000000000000000000000000", // bridged LOOKS
+  LOOKS: "",
   EXCHANGE_V2: "",
-  TRANSFER_MANAGER_V2: "0x0000000000A3573e1caFe02fe1C3Ac48473C9332",
+  TRANSFER_MANAGER_V2: "",
   WETH: "",
   ORDER_VALIDATOR_V2: "",
   REVERSE_RECORDS: "",


### PR DESCRIPTION
The `TRANSFER_MANAGER_V2` is the transfer manager used within the LooksRare Protocol.

The address I'm removing is the transfer manager used for LooksRare games.