### PR TITLE
feat: Add BLAST Sepolia chain

### DIFF
--- a/src/constants/addresses.ts
+++ b/src/constants/addresses.ts
@@ -84,6 +84,18 @@ const baseSepoliaAddresses: Addresses = {
   AGGREGATOR_UNISWAP_V3: "",
 };
 
+const blastSepoliaAddresses: Addresses = {
+  LOOKS: "",
+  EXCHANGE_V2: "",
+  TRANSFER_MANAGER_V2: "",
+  WETH: "",
+  ORDER_VALIDATOR_V2: "",
+  REVERSE_RECORDS: "",
+  LOOKS_LP_V3: "",
+  STAKING_POOL_FOR_LOOKS_LP: "",
+  AGGREGATOR_UNISWAP_V3: "",
+};
+
 /**
  * List of useful contract addresses
  */
@@ -96,4 +108,5 @@ export const addressesByNetwork: { [chainId in ChainId]: Addresses } = {
   [ChainId.ARB_MAINNET]: arbitrumMainnetAddresses,
   [ChainId.BASE_MAINNET]: baseMainnetAddresses,
   [ChainId.BASE_SEPOLIA]: baseSepoliaAddresses,
+  [ChainId.BLAST_SEPOLIA]: blastSepoliaAddresses,
 };

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -97,4 +97,16 @@ export const chainInfo: { [chainId in ChainId]: ChainInfo } = {
     cloudinaryUrl: "",
     wsUrl: "ws://localhost:5001/ws",
   },
+  [ChainId.BLAST_SEPOLIA]: {
+    label: "Blast Sepolia",
+    appUrl: "https://sepolia.looksrare.org",
+    explorer: "https://testnet.blastscan.io/",
+    rpcUrl: "https://sepolia.blast.io",
+    baseApiUrl: "https://graphql-sepolia.looksrare.org",
+    osApiUrl: "https://testnets-api.opensea.io",
+    cdnUrl: "https://static-sepolia.looksnice.org",
+    rewardsSubgraphUrl: "https://api.thegraph.com/subgraphs/name/0xjurassicpunk/looks-distribution",
+    cloudinaryUrl: "https://looksrare.mo.cloudinary.net/sepolia",
+    wsUrl: "wss://ws-sepolia.looksrare.org/ws",
+  },
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export enum ChainId {
   ARB_SEPOLIA = 421614,
   BASE_MAINNET = 8453,
   BASE_SEPOLIA = 84532,
+  BLAST_SEPOLIA = 168587773
 }
 
 /** ChainInfo data used to interact with LooksRare ecosystem */


### PR DESCRIPTION
Adds the config for Blast Sepolia. Blast mainnet will be publicly available on Februrary.

Docs here: https://docs.blast.io/building/network-information